### PR TITLE
Revert "Bump softprops/action-gh-release from 2.1.0 to 2.2.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
           zip eversolo.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           files: ${{ github.workspace }}/custom_components/eversolo/eversolo.zip


### PR DESCRIPTION
Reverts hchris1/Eversolo#107

Needs to be reverted due to https://github.com/softprops/action-gh-release/issues/555