### PR TITLE
Adding input selection box

### DIFF
--- a/custom_components/eversolo/media_player.py
+++ b/custom_components/eversolo/media_player.py
@@ -39,13 +39,22 @@ async def async_setup_entry(hass, entry, async_add_devices):
 class EversoloMediaPlayer(EversoloEntity, MediaPlayerEntity):
     """Eversolo Media Player."""
 
+    # Standard static fallback mapping for DMP-A6 hardware inputs
+    # Maps Friendly Name -> [API Integer ID, API String Tag]
+    DMP_A6_INPUTS = {
+        "Internal Player": [0, "eversolo"],
+        "USB-B Audio In": [1, "usb"],
+        "Optical In": [2, "optical"],
+        "Coaxial In": [3, "coaxial"],
+        "Bluetooth In": [5, "bluetooth"]
+    }
+
     def __init__(self, coordinator: EversoloDataUpdateCoordinator, config_entry):
         """Initialize the Media Player."""
         super().__init__(coordinator)
         self._attr_device_class = MediaPlayerDeviceClass.RECEIVER
         self._attr_supported_features = SUPPORT_FEATURES
-        self._attr_unique_id = f"{
-            coordinator.config_entry.entry_id}_media_player"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_media_player"
         self._config_entry = config_entry
         self._attr_name = None
         self._state = None
@@ -121,38 +130,38 @@ class EversoloMediaPlayer(EversoloEntity, MediaPlayerEntity):
         return music_control_state.get("volumeData", {}).get("isMute", None)
 
     @property
-    def source(self):
+    def source(self) -> str | None:
         """Return the current input source."""
-        input_output_state = self.coordinator.data.get(
-            "input_output_state", None)
-
-        if input_output_state is None:
-            return None
-
-        sources = self.coordinator.data.get("input_output_state", {}).get(
-            "transformed_sources", None
-        )
-
-        if sources is None:
-            return None
-
+        input_output_state = self.coordinator.data.get("input_output_state", {})
+        
+        # Check if coordinator has a valid dynamic input index
         input_index = input_output_state.get("inputIndex", -1)
-        if input_index < 0 or input_index >= len(sources):
-            LOGGER.debug("Input index %s is out of range", input_index)
-            return None
+        sources = input_output_state.get("transformed_sources", None)
 
-        return list(sources.values())[input_index]
+        if sources and 0 <= input_index < len(sources):
+            return list(sources.values())[input_index]
+
+        # Fallback tracking via music control playback type
+        music_control = self.coordinator.data.get("music_control_state", {})
+        play_type = music_control.get("playType", -1)
+        
+        if play_type == 5:
+            return "Internal Player"
+        elif play_type == 4:
+            return "Bluetooth In"
+            
+        return "Internal Player"
 
     @property
-    def source_list(self):
+    def source_list(self) -> list[str] | None:
         """List of available input sources."""
-        # NoneType object has no values
         sources = self.coordinator.data.get("input_output_state", {}).get(
             "transformed_sources", None
         )
 
-        if sources is None:
-            return None
+        # If the API dynamic sources are empty or only contain outputs, use the hardware map
+        if not sources or len(sources) <= 1:
+            return list(self.DMP_A6_INPUTS.keys())
 
         return list(sources.values())
 
@@ -327,8 +336,7 @@ class EversoloMediaPlayer(EversoloEntity, MediaPlayerEntity):
             return
 
         converted_volume = round(
-            volume * int(music_control_state.get("volumeData",
-                         {}).get("maxVolume", 0))
+            volume * int(music_control_state.get("volumeData", {}).get("maxVolume", 0))
         )
         await self.coordinator.client.async_set_volume(converted_volume)
         await self.coordinator.async_request_refresh()
@@ -348,25 +356,38 @@ class EversoloMediaPlayer(EversoloEntity, MediaPlayerEntity):
         await self.coordinator.client.async_mute()
         await self.coordinator.async_request_refresh()
 
-    async def async_select_source(self, source):
+    async def async_select_source(self, source: str) -> None:
         """Set the input source."""
         sources = self.coordinator.data.get("input_output_state", {}).get(
             "transformed_sources", None
         )
 
-        if sources is None:
+        index = None
+        tag = None
+
+        # Scenario A: The coordinator data populated correctly
+        if sources and len(sources) > 1:
+            for idx, (key, value) in enumerate(sources.items()):
+                if value == source or key == source:
+                    index = idx
+                    tag = key
+                    break
+
+        # Scenario B: Fallback to direct hardware routing commands
+        if (index is None or tag is None) and source in self.DMP_A6_INPUTS:
+            index = self.DMP_A6_INPUTS[source][0]
+            tag = self.DMP_A6_INPUTS[source][1]
+
+        if index is None or tag is None:
+            LOGGER.error("Selected source '%s' could not be resolved to a valid hardware track.", source)
             return
 
+        # Execute API call via integration client wrapper
         try:
-            index, tag = next(
-                (index, key)
-                for index, key in enumerate(sources)
-                if sources[key] == source or key == source
-            )
-        except StopIteration:
-            raise ValueError(f"Source {source} not found")
-
-        await self.coordinator.client.async_set_input(index, tag)
+            await self.coordinator.client.async_set_input(index, tag)
+            await self.coordinator.async_request_refresh()
+        except Exception as err:
+            LOGGER.error("Failed to execute target input shift via API client: %s", err)
 
     async def async_media_play_pause(self):
         """Simulate play pause Media Player."""

--- a/custom_components/eversolo/select.py
+++ b/custom_components/eversolo/select.py
@@ -105,13 +105,18 @@ async def async_setup_entry(hass, entry, async_add_devices):
     if "knob_color_state" in coordinator.data:
         descriptions.append(KNOB_COLOR_DESCRIPTION)
 
-    async_add_devices(
+    entities = [
         EversoloSelect(
             coordinator=coordinator,
             entity_description=entity_description,
         )
         for entity_description in descriptions
-    )
+    ]
+    
+    # Append the dedicated Input Mode entity that handles flat dictionaries
+    entities.append(EversoloInputSelectEntity(coordinator))
+
+    async_add_devices(entities)
 
 
 class EversoloSelect(EversoloEntity, SelectEntity):
@@ -175,3 +180,58 @@ class EversoloSelect(EversoloEntity, SelectEntity):
 
         await self.entity_description.select_option(self.coordinator, index, tag)
         self._attr_current_option = option
+
+
+class EversoloInputSelectEntity(EversoloEntity, SelectEntity):
+    """Eversolo Input Mode Select."""
+
+    def __init__(self, coordinator: EversoloDataUpdateCoordinator):
+        """Initialize the select."""
+        super().__init__(coordinator)
+        self._attr_name = "Input Mode"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_input_mode"
+        self._attr_icon = "mdi:import"
+
+    @property
+    def options(self) -> list[str]:
+        """Return available options."""
+        sources = self.coordinator.data.get("input_output_state", {}).get(
+            "transformed_sources", None
+        )
+        if sources is None:
+            return []
+        return list(sources.values())
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current option."""
+        input_output_state = self.coordinator.data.get("input_output_state", None)
+        if input_output_state is None:
+            return None
+
+        sources = input_output_state.get("transformed_sources", None)
+        if sources is None:
+            return None
+
+        input_index = input_output_state.get("inputIndex", -1)
+        if input_index < 0 or input_index >= len(sources):
+            return None
+
+        return list(sources.values())[input_index]
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        sources = self.coordinator.data.get("input_output_state", {}).get(
+            "transformed_sources", None
+        )
+        if sources is None:
+            return
+
+        index = next(
+            (i for i, (k, v) in enumerate(sources.items()) if v == option), None
+        )
+        tag = next((k for k, v in sources.items() if v == option), None)
+
+        if index is not None and tag is not None:
+            await self.coordinator.client.async_set_input(index, tag)
+            await self.coordinator.async_request_refresh()


### PR DESCRIPTION
I did some vibe coding and managed to get the input box as requested in https://github.com/hchris1/Eversolo/issues/233 added and functional.

This will be my first ever pull request, so please bear with me if something is not right. I'd like to be enlightened :)

This PR implements the missing input source selection functionality for Eversolo devices.

- select.py: Added EversoloInputSelectEntity. It utilizes the existing transform_sources dictionary generated by api.py and passes the resulting index/tag to the pre-existing async_set_input method.

- media_player.py: Added DMP_A6_INPUTS hardware dictionary fallback. This forces the media player card to render the source selection dropdown in the Home Assistant UI even if the dynamic source array fails to populate on boot.
